### PR TITLE
kerbinSMA alteration

### DIFF
--- a/Source-Code/FlareDraw.cs
+++ b/Source-Code/FlareDraw.cs
@@ -192,9 +192,22 @@ namespace DistantObject
             //ListChildren(sm.systemPrefab.rootBody, 0);
             //--- HACK--
 
+            //If Kerbin is parented to the Sun, set its SMA- otherwise iterate
+            //through celestial bodies to locate which is parented to the Sun
+            //and has Kerbin as a child. Set the highest parents SMA to kerbinSMA
             if(BodyFlare.kerbinSMA <= 0.0)
             {
-                BodyFlare.kerbinSMA = FlightGlobals.Bodies[1].orbit.semiMajorAxis;
+                if(FlightGlobals.Bodies[1].referenceBody == FlightGlobals.Bodies[0])
+                    BodyFlare.kerbinSMA = FlightGlobals.Bodies[1].orbit.semiMajorAxis;
+                else
+                {                    
+                    foreach(CelestialBody current in FlightGlobals.Bodies)
+                    {
+                        if(current != FlightGlobals.Bodies[0])
+                            if (current.referenceBody == FlightGlobals.Bodies[0] && current.HasChild(FlightGlobals.Bodies[1]))
+                                BodyFlare.kerbinSMA = current.orbit.semiMajorAxis;
+                    }
+                }
                 BodyFlare.kerbinRadius = FlightGlobals.Bodies[1].Radius;
             }
             bodyFlares.Clear();


### PR DESCRIPTION
Updated to take into account Kerbin being parented to a body other than the sun. This change will set Kerbin's SMA if the Sun is it's direct parent, or look for the body that Kerbin orbits and has the Sun as it's direct parent and use it's SMA as the new kerbinSMA.