### PR TITLE
Update RSS configs / celestial body names

### DIFF
--- a/Alternate Planet Color Configs/Real Solar System (default)/DistantObject/PlanetColors.cfg
+++ b/Alternate Planet Color Configs/Real Solar System (default)/DistantObject/PlanetColors.cfg
@@ -4,49 +4,49 @@
 //Mercury
 CelestialBodyColor
 {
-	name = Moho
+	name = Mercury
 	color = 128,128,128
 }
 //---------------------
 //Venus
 CelestialBodyColor
 {
-	name = Eve
+	name = Venus
 	color = 179,174,155
 }
 //---------------------
 //Earth
 CelestialBodyColor
 {
-	name = Kerbin
+	name = Earth
 	color = 73,99,121
 }
 //---------------------
 //Moon
 CelestialBodyColor
 {
-	name = Mun
+	name = Moon
 	color = 80,82,81
 }
 //---------------------
 //Mars
 CelestialBodyColor
 {
-	name = Duna
+	name = Mars
 	color = 175,132,90
 }
 //---------------------
 //Phobos
 CelestialBodyColor
 {
-	name = Bop
+	name = Phobos
 	color = 138,124,115
 }
 //---------------------
 //Deimos
 CelestialBodyColor
 {
-	name = Gilly
+	name = Deimos
 	color = 163,150,141
 }
 //---------------------
@@ -60,7 +60,7 @@ CelestialBodyColor
 //Io
 CelestialBodyColor
 {
-	name = Pol
+	name = Io
 	color = 199,188,73
 }
 //---------------------
@@ -74,41 +74,41 @@ CelestialBodyColor
 //Ganymede
 CelestialBodyColor
 {
-	name = Tylo
+	name = Ganymede
 	color = 111,104,88
 }
 //---------------------
 //Callisto
 CelestialBodyColor
 {
-	name = Ike
+	name = Callisto
 	color = 142,110,89
 }
 //---------------------
 //Saturn
 CelestialBodyColor
 {
-	name = Dres
+	name = Saturn
 	color = 188,165,131
 }
 //---------------------
 //Titan
 CelestialBodyColor
 {
-	name = Laythe
+	name = Titan
 	color = 235,203,80
 }
 //---------------------
 //Uranus
 CelestialBodyColor
 {
-	name = Minmus
+	name = Uranus
 	color = 169,208,213
 }
 //---------------------
 //Pluto
 CelestialBodyColor
 {
-	name = Vall
+	name = Pluto
 	color = 92,56,34
 }

--- a/Alternate Planet Color Configs/Real Solar System (metaphor's PlanetFactory config)/DistantObject/PlanetColors.cfg
+++ b/Alternate Planet Color Configs/Real Solar System (metaphor's PlanetFactory config)/DistantObject/PlanetColors.cfg
@@ -4,70 +4,70 @@
 //Mercury
 CelestialBodyColor
 {
-	name = Moho
+	name = Mercury
 	color = 128,128,128
 }
 //---------------------
 //Venus
 CelestialBodyColor
 {
-	name = Eve
+	name = Venus
 	color = 179,174,155
 }
 //---------------------
 //Earth
 CelestialBodyColor
 {
-	name = Kerbin
+	name = Earth
 	color = 73,99,121
 }
 //---------------------
 //Moon
 CelestialBodyColor
 {
-	name = Mun
+	name = Moon
 	color = 80,82,81
 }
 //---------------------
 //Mars
 CelestialBodyColor
 {
-	name = Duna
+	name = Mars
 	color = 175,132,90
 }
 //---------------------
 //Phobos
 CelestialBodyColor
 {
-	name = Bop
+	name = Phobos
 	color = 138,124,115
 }
 //---------------------
 //Deimos
 CelestialBodyColor
 {
-	name = Gilly
+	name = Deimos
 	color = 163,150,141
 }
 //---------------------
 //Vesta
 CelestialBodyColor
 {
-	name = Inaccessable
+	name = Vesta
 	color = 128,128,128
 }
 //---------------------
 //Ceres
 CelestialBodyColor
 {
-	name = Minmus
+	name = Ceres
 	color = 190,181,172
 }
 //---------------------
 //Jupiter
 CelestialBodyColor
 {
-	name = Jool
+	name = Jupiter
 	color = 172,153,139
 }
 //---------------------
@@ -81,97 +81,97 @@ CelestialBodyColor
 //Europa
 CelestialBodyColor
 {
-	name = Eeloo
+	name = Europa
 	color = 155,144,116
 }
 //---------------------
 //Ganymede
 CelestialBodyColor
 {
-	name = Tylo
+	name = Ganymede
 	color = 111,104,88
 }
 //---------------------
 //Callisto
 CelestialBodyColor
 {
-	name = Ike
+	name = Callisto
 	color = 142,110,89
 }
 //---------------------
 //Saturn
 CelestialBodyColor
 {
-	name = Sentar
+	name = Saturn
 	color = 188,165,131
 }
 //---------------------
 //Enceladus
 CelestialBodyColor
 {
-	name = Vall
+	name = Enceladus
 	color = 128,128,128
 }
 //---------------------
 //Titan
 CelestialBodyColor
 {
-	name = Erin
+	name = Titan
 	color = 235,203,80
 }
 //---------------------
 //Iapetus
 CelestialBodyColor
 {
-	name = Ringle
+	name = Iapetus
 	color = 96,96,96
 }
 //---------------------
 //Uranus
 CelestialBodyColor
 {
-	name = Skelton
+	name = Uranus
 	color = 169,208,213
 }
 //---------------------
 //Miranda
 CelestialBodyColor
 {
-	name = Ablate
+	name = Miranda
 	color = 160,160,160
 }
 //---------------------
 //Titania
 CelestialBodyColor
 {
-	name = Thud
+	name = Titania
 	color = 176,166,154
 }
 //---------------------
 //Neptune
 CelestialBodyColor
 {
-	name = Laythe
+	name = Neptune
 	color = 73,118,199
 }
 //---------------------
 //Triton
 CelestialBodyColor
 {
-	name = Ascension
+	name = Triton
 	color = 112,118,108
 }
 //---------------------
 //Pluto
 CelestialBodyColor
 {
-	name = Dres
+	name = Pluto
 	color = 92,56,34
 }
 //---------------------
 //Charon
 CelestialBodyColor
 {
-	name = Pock
+	name = Charon
 	color = 65,60,55
 }


### PR DESCRIPTION
- Recent changes made the old naming system obsolete and Kopernicus bodies can now be addressed by their ingame names
- fixed RSS names for both supplied configs (though the PlanetFactory config might reference bodies only available with RSS Expanded)

